### PR TITLE
Make __init__ a noop during precompilation

### DIFF
--- a/src/HostCPUFeatures.jl
+++ b/src/HostCPUFeatures.jl
@@ -44,11 +44,11 @@ unwrap(::StaticSymbol{S}) where {S} = S
 end
 const BASELINE_CPU_NAME = get_cpu_name()
 function __init__()
+  ccall(:jl_generating_output, Cint, ()) == 1 && return
   if Sys.ARCH === :x86_64 || Sys.ARCH === :i686
     target = Base.unsafe_string(Base.JLOptions().cpu_target)
     occursin("native",  target) || return make_generic(target)
   end
-  ccall(:jl_generating_output, Cint, ()) == 1 && return
   BASELINE_CPU_NAME == Sys.CPU_NAME::String || redefine()
   return nothing
 end


### PR DESCRIPTION
This fixes #12 by making precompilation work properly, even with pkgimages. The contents of `__init__` should no longer execute while precompiling code to disk.