### PR TITLE
Add Preference to disable runtime invalidation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.5'
+          - '1.10'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.1.17"
 BitTwiddlingConvenienceFunctions = "62783981-4cbd-42fc-bca8-16325de8dc4b"
 IfElse = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 BitTwiddlingConvenienceFunctions = "0.1"
 IfElse = "0.1"
 Static = "0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 1"
-julia = "1.5"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -12,3 +12,9 @@ Documentation for [HostCPUFeatures](https://github.com/JuliaSIMD/HostCPUFeatures
 ```@autodocs
 Modules = [HostCPUFeatures]
 ```
+
+## Supported Preferences
+
+  - `cpu_target`: if provided, use this string as your CPU target for feature detection instead of `JULIA_CPU_TARGET`
+  - `freeze_cpu_target`: if `true`, "freeze" the features detected based on your precompile-time CPU target and do not perform runtime feature detection
+  - `allow_runtime_invalidation`: if `false`, warn when performing runtime feature detection (instead of invalidating) when CPU features don't match precompile-time

--- a/src/cpu_info.jl
+++ b/src/cpu_info.jl
@@ -39,9 +39,10 @@ function set_features!()
   end
   Libc.free(features_cstring)
 end
-set_features!()
 
-
+if build_cpu_target == "native"
+    set_features!()
+end
 
 function reset_features!()
     features, features_cstring = feature_string()
@@ -70,5 +71,8 @@ function redefine_cpu_name()
       @warn "Runtime invalidation was disabled, but the CPU info is out-of-date.\nWill continue with incorrect CPU name (from build time)."
     end
 end
-cpu = QuoteNode(Symbol(get_cpu_name()))
-@eval cpu_name() = Val{$cpu}()
+
+let _cpu = QuoteNode(Symbol(build_cpu_target == "native" ?
+			    get_cpu_name() : build_cpu_target))
+   @eval cpu_name() = Val{$_cpu}()
+end

--- a/src/cpu_info_aarch64.jl
+++ b/src/cpu_info_aarch64.jl
@@ -28,7 +28,7 @@ function _set_sve_vector_width!(bytes = _dynamic_register_size())
 end
 
 
-if _has_aarch64_sve()# && !(Bool(has_feature(Val(:aarch64_sve))))
+if build_cpu_target == "native" && _has_aarch64_sve()# && !(Bool(has_feature(Val(:aarch64_sve))))
     has_feature(::Val{:aarch64_sve_cpuid}) = True()
     _set_sve_vector_width!()
 else

--- a/src/cpu_info_aarch64.jl
+++ b/src/cpu_info_aarch64.jl
@@ -39,10 +39,20 @@ end
 
 function reset_extra_features!()
     drs = _dynamic_register_size()
-    register_size() ≠ drs && _set_sve_vector_width!(drs)
+    if register_size() ≠ drs
+        if allow_eval
+            _set_sve_vector_width!(drs)
+        else
+            @warn "Runtime invalidation was disabled, but the CPU info is out-of-date.\nWill continue with incorrect CPU register size."
+        end
+    end
     hassve = _has_aarch64_sve()
     if hassve ≠ has_feature(Val(:aarch64_sve_cpuid))
-        @eval has_feature(::Val{:aarch64_sve_cpuid}) = $(Expr(:call, hassve ? :True : :False))
+        if allow_eval
+            @eval has_feature(::Val{:aarch64_sve_cpuid}) = $(Expr(:call, hassve ? :True : :False))
+        else
+            @warn "Runtime invalidation was disabled, but the CPU info is out-of-date.\nWill continue with incorrect CPU feature flag: :aarch64_sve_cpuid."
+        end
     end
 end
 

--- a/src/cpu_info_x86.jl
+++ b/src/cpu_info_x86.jl
@@ -51,7 +51,7 @@ end
   end
 end
 
-function make_generic(target)
+function make_generic_x86(target)
   if occursin("tigerlake", target) || occursin("znver4", target) || occursin("sapphirerapids", target)
     # most feature-complete architectures we use
     setfeaturetrue(:x86_64_avx512ifma)

--- a/src/cpu_info_x86.jl
+++ b/src/cpu_info_x86.jl
@@ -32,14 +32,22 @@ fast_int64_to_double() = has_feature(Val(:x86_64_avx512dq))
 
 fast_half() = False()
 
-@noinline function setfeaturefalse(s)
+@inline function setfeaturefalse(s)
   if has_feature(Val(s)) === True()
-    @eval has_feature(::Val{$(QuoteNode(s))}) = False()
+    if allow_eval
+      @eval has_feature(::Val{$(QuoteNode(s))}) = False()
+    else
+      @warn "Runtime invalidation was disabled, but the CPU info is out-of-date.\nWill continue with incorrect CPU feature flag: $s."
+    end
   end
 end
-@noinline function setfeaturetrue(s)
+@inline function setfeaturetrue(s)
   if has_feature(Val(s)) === False()
-    @eval has_feature(::Val{$(QuoteNode(s))}) = True()
+    if allow_eval
+      @eval has_feature(::Val{$(QuoteNode(s))}) = True()
+    else
+      @warn "Runtime invalidation was disabled, but the CPU info is out-of-date.\nWill continue with incorrect CPU feature flag: $s."
+    end
   end
 end
 


### PR DESCRIPTION
More conservative version of https://github.com/JuliaSIMD/HostCPUFeatures.jl/pull/21 (thanks to @el-oso for the inspiration).

Adds three preferences:
  - `cpu_target`: if provided, use this for feature detection instead of `JULIA_CPU_TARGET`
  - `freeze_cpu_target`: if `true`, "freeze" the features detected based on your precompile-time CPU target
  - `allow_runtime_invalidation`: if `false`, warn instead of invalidating when CPU features don't match precompile-time

```julia
┌ Warning: Runtime invalidation was disabled, but the CPU info is out-of-date.
│ Will continue with incorrect CPU name (from build time).
└ @ HostCPUFeatures ~/repos/HostCPUFeatures.jl/src/HostCPUFeatures.jl:62
```

This makes the package `--trim` compatible and also provides a nice preference for users who do not wish for HostCPUFeatures.jl to ever cause an "invalidation storm", even if it means running with the wrong CPU info.
